### PR TITLE
Open Record Types, Update Module Version and Fix renameSheet operation issue

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "googleapis_sheets"
-version = "0.99.5"
+version = "0.99.6"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["sheets", "google", "spreadsheet"]

--- a/Module.md
+++ b/Module.md
@@ -96,7 +96,7 @@ Adding values to a given range and retrieving values from a range
         ["Nisha", "98"],
         ["Kana", "86"]
     ];
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         Range range = {a1Notation: a1Notation, values: entries};
         error? response = spreadsheetClient->setRange(<spreadsheetId>, <worksheet-name>, range);
@@ -106,7 +106,7 @@ Adding values to a given range and retrieving values from a range
 
 Adding values to a cell and retrieving values from a cell
 ```ballerina
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         error? setValueResult = spreadsheetClient->setCell(<spreadsheetId>, <worksheet-name>, "A10", "Foo");
         int|string|float|error getValueResult = spreadsheetClient->getCell(<spreadsheetId>, <worksheet-name>, "A10");
@@ -115,7 +115,7 @@ Adding values to a cell and retrieving values from a cell
 
 Retrieving values from a column
 ```ballerina
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         (string|int|float)[]|error getValueResult = spreadsheetClient->getColumn(<spreadsheetId>, <worksheet-name>, "C");
     }
@@ -123,7 +123,7 @@ Retrieving values from a column
 
 Retrieving values from a row
 ```ballerina
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         (string|int|float)[]|error getValueResult = spreadsheetClient->getRow(<spreadsheetId>, <worksheet-name>, 3);
     }
@@ -132,7 +132,7 @@ Retrieving values from a row
 Appending values to a sheet
 ```ballerina
     string[] values = ["Appending", "Some", "Values"];
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         error? appendResult = spreadsheetClient->appendRowToSheet(<spreadsheetId>, <worksheet-name>, values);
     }

--- a/Package.md
+++ b/Package.md
@@ -79,7 +79,7 @@ Adding values to a given range and retrieving values from a range
         ["Nisha", "98"],
         ["Kana", "86"]
     ];
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         Range range = {a1Notation: a1Notation, values: entries};
         error? response = spreadsheetClient->setRange(<spreadsheetId>, <worksheet-name>, range);
@@ -89,7 +89,7 @@ Adding values to a given range and retrieving values from a range
 
 Adding values to a cell and retrieving values from a cell
 ```ballerina
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         error? setValueResult = spreadsheetClient->setCell(<spreadsheetId>, <worksheet-name>, "A10", "Foo");
         int|string|float|error getValueResult = spreadsheetClient->getCell(<spreadsheetId>, <worksheet-name>, "A10");
@@ -98,7 +98,7 @@ Adding values to a cell and retrieving values from a cell
 
 Retrieving values from a column
 ```ballerina
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         (string|int|float)[]|error getValueResult = spreadsheetClient->getColumn(<spreadsheetId>, <worksheet-name>, "C");
     }
@@ -106,7 +106,7 @@ Retrieving values from a column
 
 Retrieving values from a row
 ```ballerina
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         (string|int|float)[]|error getValueResult = spreadsheetClient->getRow(<spreadsheetId>, <worksheet-name>, 3);
     }
@@ -115,7 +115,7 @@ Retrieving values from a row
 Appending values to a sheet
 ```ballerina
     string[] values = ["Appending", "Some", "Values"];
-    sheets:Sheet|error sheet = spreadsheetRes = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
+    sheets:Sheet|error sheet = spreadsheetClient->getSheetByName(<spreadsheetId>, <worksheet-name>);
     if (sheet is sheets:Sheet) {
         error? appendResult = spreadsheetClient->appendRowToSheet(<spreadsheetId>, <worksheet-name>, values);
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/ballerina-platform/module-ballerinax-googleapis.sheets.svg?branch=master)](https://travis-ci.org/ballerina-ballerinax-platform/module-ballerinax-googleapis.sheets)
 
-# Ballerina Google Spreadsheet Endpoint
+# Ballerina Google Spreadsheet Connector
 
 Google Sheets is an online spreadsheet that lets users create and format
 spreadsheets and simultaneously work with other people. The Google Spreadsheet endpoint allows you to access the Google Spreadsheet API Version v4 through Ballerina.

--- a/client.bal
+++ b/client.bal
@@ -250,14 +250,16 @@ public client class Client {
     # Renames the first sheet of the spreadsheet with the given name.
     #
     # + spreadsheetId - ID of the Spreadsheet
+    # + sheetName - The name of the Worksheet
     # + name - New name for the worksheet
     # + return - Nil on success, else returns an error
-    remote function renameSheet(string spreadsheetId, string name) returns @tainted error? {
+    remote function renameSheet(string spreadsheetId, string sheetName, string name) returns @tainted error? {
+        Sheet sheet = check self->getSheetByName(spreadsheetId, sheetName);
         json payload = {
             "requests": [
                 {
                     "updateSheetProperties": {
-                        "properties": {"title": name},
+                        "properties": {"sheetId": sheet.properties.sheetId, "title": name},
                         "fields": "title"
                     }
                 }

--- a/client.bal
+++ b/client.bal
@@ -518,8 +518,8 @@ public client class Client {
             ]
         };
         http:Request request = new();
-        request.setJsonPayload(jsonPayload);
-        http:Response httpResponse = <http:Response> check self.httpClient->put(requestPath, request);
+        request.setJsonPayload(<@untainted>jsonPayload);
+        http:Response httpResponse = <http:Response> check self.httpClient->put(<@untainted>requestPath, request);
         if (httpResponse.statusCode == http:STATUS_OK) {
             json jsonResponse = check httpResponse.getJsonPayload();
             return; 
@@ -778,8 +778,8 @@ public client class Client {
             ]
         };
         http:Request request = new();
-        request.setJsonPayload(jsonPayload);
-        http:Response httpResponse = <http:Response> check self.httpClient->put(requestPath, request);
+        request.setJsonPayload(<@untainted>jsonPayload);
+        http:Response httpResponse = <http:Response> check self.httpClient->put(<@untainted>requestPath, request);
         if (httpResponse.statusCode == http:STATUS_OK) {
             json jsonResponse = check httpResponse.getJsonPayload();
             return; 

--- a/metadata/google_sheet.json
+++ b/metadata/google_sheet.json
@@ -198,6 +198,10 @@
                                 "displayName": "Spreadsheet ID"
                             },
                             {
+                                "name": "sheetName",
+                                "displayName": "Sheet Name"
+                            },
+                            {
                                 "name": "name",
                                 "displayName": "New Name For Sheet"
                             }

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -165,7 +165,7 @@ function testGetSheetByName() {
 }
 function testRenameSheet() {
     string newName = testSheetName + " Renamed";
-    var spreadsheetRes = spreadsheetClient->renameSheet(spreadsheetId, newName);
+    var spreadsheetRes = spreadsheetClient->renameSheet(spreadsheetId, "Sheet1", newName);
     if (spreadsheetRes is ()) {
         var openRes = spreadsheetClient->getSheetByName(spreadsheetId, newName);
         if (openRes is Sheet) {

--- a/types.bal
+++ b/types.bal
@@ -19,30 +19,30 @@
 # + properties - Properties of a spreadsheet
 # + sheets - The sheets that are part of a spreadsheet
 # + spreadsheetUrl - The URL of the spreadsheet
-public type Spreadsheet record {|
+public type Spreadsheet record {
     string spreadsheetId = "";
     SpreadsheetProperties properties = {};
     Sheet[] sheets = [];
     string spreadsheetUrl = "";
-|};
+};
 
 # Sheet.
 # + properties - Properties of a sheet
-public type Sheet record {|
+public type Sheet record {
     SheetProperties properties = {};
-|};
+};
 
 # Spreadsheet properties.
 # + title - The title of the spreadsheet
 # + locale - The locale of the spreadsheet
 # + autoRecalc - The amount of time to wait before volatile functions are recalculated
 # + timeZone - The time zone of the spreadsheet
-public type SpreadsheetProperties record {|
+public type SpreadsheetProperties record {
     string title = "";
     string locale = "";
     string autoRecalc = "";
     string timeZone = "";
-|};
+};
 
 # Sheet properties.
 # + sheetId - The ID of the sheet
@@ -52,7 +52,7 @@ public type SpreadsheetProperties record {|
 # + gridProperties - Additional properties of the sheet if this sheet is a grid
 # + hidden - True if the sheet is hidden in the UI, false if it is visible
 # + rightToLeft - True if the sheet is an RTL sheet instead of an LTR sheet
-public type SheetProperties record {|
+public type SheetProperties record {
     int sheetId = 0;
     string title = "";
     int index = 0;
@@ -60,7 +60,7 @@ public type SheetProperties record {|
     GridProperties gridProperties = {};
     boolean hidden = false;
     boolean rightToLeft = false;
-|};
+};
 
 # Grid properties.
 # + rowCount - The number of rows in the grid
@@ -68,13 +68,13 @@ public type SheetProperties record {|
 # + frozenRowCount - The number of rows that are frozen in the grid
 # + frozenColumnCount - The number of columns that are frozen in the grid
 # + hideGridlines - True if the grid is not showing gridlines in the UI
-public type GridProperties record {|
+public type GridProperties record {
     int rowCount = 0;
     int columnCount = 0;
     int frozenRowCount = 0;
     int frozenColumnCount = 0;
     boolean hideGridlines = false;
-|};
+};
 
 # Single cell or a group of adjacent cells in a sheet.
 #
@@ -87,16 +87,16 @@ public type Range record {
    (int|string|float)[][] values;
 };
 
-public type FilesResponse record {|
+public type FilesResponse record {
     string kind;
     string nextPageToken?;
     boolean incompleteSearch;
     File[] files;
-|};
+};
 
-public type File record {|
+public type File record {
     string kind;
     string id;
     string name;
     string mimeType;
-|};
+};


### PR DESCRIPTION
## Purpose
> To open all the closed record types to prevent issues caused in choreo due to the usage of close record types. Third party API  payload should be mapped with open records. 
> renameSheet operation had an issue that rename only the first sheet of the Spreadsheet. This PR fix it so that user can rename any sheet

## Goals
> To open record types, update module version and fix renameSheet operation issue

## Approach
> Open all the closed record types and update module version
> renameSheet operation was improved to get a new input parameter of the sheet name to rename

## Automation tests
 - Unit tests 
   > For all the implemented operations
 - Integration tests
   > Automated

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11
Ballerina SLP8
Ubuntu 20.04 OS