### PR TITLE
Add JAVA_HOME environment variable to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,4 +56,6 @@ jobs:
                   args:
                       push
               env:
+                  WORKING_DIR: ./gsheet
+                  JAVA_HOME: /usr/lib/jvm/default-jvm
                   BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Purpose
> Github workflow for the release.yml failed because the JAVA_HOME environment variable was not explicitly defined. This PR add this JAVA_HOME environment variable to release.yml.

## Goals
> Pass the release workflow and release the connector.

## Approach
> Add JAVA_HOME environment variable to release.yml.

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/pull/137

## Test environment
>
SLAlpha 4
JDK 11
Ubuntu 20.04
