### PR TITLE
Fix ballerina build failure

### DIFF
--- a/gsheet/Dependencies.toml
+++ b/gsheet/Dependencies.toml
@@ -5,11 +5,6 @@ version = "0.8.0-beta.1"
 
 [[dependency]]
 org = "ballerina"
-name = "test"
-version = "0.0.0"
-
-[[dependency]]
-org = "ballerina"
 name = "log"
 version = "1.1.0-beta.1"
 


### PR DESCRIPTION
## Purpose

- Fix https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/issues/146

## Goals

- Fix the ballerina build failure

## Description

If we have the 
```
[[dependency]]
org = "ballerina"
name = "test"
version = "0.0.0"
```
in Dependencies.toml, 
build will fail.

## Approach

- Remove test module version in Dependencies.toml

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test Environment
- Ubuntu
- Ballerina Docker Image ballerina/ballerina:nightly-2021-05-15
 