### PR TITLE
Fix returning trash files & add stream implementer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.googleapis.sheets
-version=0.99.8
+version=0.99.9
 ballerinaLangVersion=2.0.0-alpha8-20210423-135000-530658ec

--- a/gsheet/Ballerina.toml
+++ b/gsheet/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "googleapis.sheets"
-version = "0.99.8"
+version = "0.99.9"
 export= ["googleapis.sheets", "googleapis.sheets.listener"]
 license= ["Apache-2.0"]
 authors = ["Ballerina"]

--- a/gsheet/client.bal
+++ b/gsheet/client.bal
@@ -94,9 +94,8 @@ public client class Client {
     # 
     # + return - Array of files records on success, else returns an error
     @display {label: "Get all spreadsheets"}
-    remote function getAllSpreadsheets() returns @tainted @display {label: "Spreadsheets"} stream<File>|error {
-        File[] files = [];
-        return getFilesStream(self.driveClient, files);
+    remote isolated function getAllSpreadsheets() returns @tainted @display {label: "Spreadsheets"} stream<File,error>|error {
+        return new stream<File,error>(new SpreadsheetStream(self.driveClient));
     }
 
     isolated function getIdFromUrl(string url) returns string|error {

--- a/gsheet/constants.bal
+++ b/gsheet/constants.bal
@@ -53,6 +53,8 @@ const string Q = "q";
 const string MIME_TYPE = "mimeType";
 const string APPLICATION = "'application/vnd.google-apps.spreadsheet'";
 const string AND = "&";
+const string AND_SIGN = "and";
+const string TRASH_FALSE ="trashed=false";
 const string PAGE_TOKEN = "pageToken";
 
 // Error

--- a/gsheet/samples/getAllSpreadsheets.bal
+++ b/gsheet/samples/getAllSpreadsheets.bal
@@ -35,8 +35,8 @@ sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
 public function main() {
 
     // Get All Spreadsheets associated with the user account
-    stream<sheets:File>|error response = spreadsheetClient->getAllSpreadsheets();
-    if (response is stream<sheets:File>) {
+    stream<sheets:File,error>|error response = spreadsheetClient->getAllSpreadsheets();
+    if (response is stream<sheets:File, error>) {
         error? e = response.forEach(function (sheets:File spreadsheet) {
             log:printInfo("Spreadsheet Name: " + spreadsheet.name.toString() + " | Spreadsheet ID: " 
                 + spreadsheet.id.toString());

--- a/gsheet/stream_implementer.bal
+++ b/gsheet/stream_implementer.bal
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+class SpreadsheetStream {
+    private final http:Client httpClient;
+    private string? pageToken;
+    private File[] currentEntries = [];
+    int index = 0;   
+
+    isolated function init(http:Client httpClient) {
+        self.httpClient = httpClient;
+        self.pageToken = EMPTY_STRING;
+        self.currentEntries = checkpanic self.fetchFiles();
+    }
+
+    public isolated function next() returns @tainted record {|File value;|}|error? {
+        if (self.index < self.currentEntries.length()) {
+            record {|File value;|} file = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return file;
+        }
+
+        if (self.pageToken is string) {
+            self.index = 0;
+            self.currentEntries = check self.fetchFiles();
+            record {|File value;|} file = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return file;
+        }
+    }
+
+    isolated function fetchFiles() returns @tainted File[]|error {
+        string drivePath = <@untainted>prepareDriveUrl(self.pageToken);
+        json response = check sendRequest(self.httpClient, drivePath);
+        FilesResponse|error filesResponse = response.cloneWithType(FilesResponse);
+        if (filesResponse is FilesResponse) {
+            self.pageToken = filesResponse?.nextPageToken;
+            return filesResponse.files;
+        } else {
+            return error(ERR_FILE_RESPONSE, filesResponse);
+        }
+    }
+}

--- a/gsheet/tests/test.bal
+++ b/gsheet/tests/test.bal
@@ -114,9 +114,13 @@ function testRenameSpreadsheet() {
 function testGetAllSpreadSheets() {
     log:printInfo("testGetAllSpreadSheets");    
     var response = spreadsheetClient->getAllSpreadsheets();
-    if (response is stream<File>) {
-        var file = response.next();
-        test:assertNotEquals(file?.value, "", msg = "Found 0 records");
+    if (response is stream<File,error>) {
+        record {|File value;|}|error? fileResponse = response.next();
+        if (fileResponse is record {|File value;|}) {
+            test:assertNotEquals(fileResponse.value["id"], "", msg = "Found 0 records");
+        } else if (fileResponse is error) {
+            test:assertFail(fileResponse.message());
+        }
     } else {
         test:assertFail(response.message());
     }

--- a/gsheet/utils.bal
+++ b/gsheet/utils.bal
@@ -119,10 +119,13 @@ isolated function getErrorMessage(http:Response response) returns @tainted error
 # + files - File array
 # + pageToken - Token for retrieving next page
 # + return - File stream on success, else an error
-function getFilesStream(http:Client driveClient, @tainted File[] files, string? pageToken = ()) returns @tainted stream<File>|error {
-    string drivePath = DRIVE_PATH + FILES + QUESTION_MARK + Q + EQUAL + MIME_TYPE + EQUAL + APPLICATION;
+function getFilesStream(http:Client driveClient, @tainted File[] files, string? pageToken = ()) 
+                        returns @tainted stream<File>|error {
+    string drivePath = DRIVE_PATH + FILES + QUESTION_MARK + Q + EQUAL + MIME_TYPE + EQUAL + APPLICATION + 
+        AND_SIGN + TRASH_FALSE;
     if (pageToken is string) {
-        drivePath = DRIVE_PATH + FILES + QUESTION_MARK + Q + EQUAL + MIME_TYPE + EQUAL + APPLICATION + AND + PAGE_TOKEN + EQUAL + pageToken;
+        drivePath = DRIVE_PATH + FILES + QUESTION_MARK + Q + EQUAL + MIME_TYPE + EQUAL + APPLICATION + 
+            AND_SIGN + TRASH_FALSE + AND + PAGE_TOKEN + EQUAL + pageToken;
     }
     json|error resp = sendRequest(driveClient, drivePath);
     if (resp is json) {

--- a/gsheet/utils.bal
+++ b/gsheet/utils.bal
@@ -150,6 +150,22 @@ function getFilesStream(http:Client driveClient, @tainted File[] files, string? 
     }
 }
 
+# Get the drive url path to get a list of files.
+# 
+# + pageToken - Token for retrieving next page (Optional)
+# + return - drive url on success, else an error
+isolated function prepareDriveUrl(string? pageToken = ()) returns string {
+    string drivePath;
+    if (pageToken is string) {
+        drivePath = DRIVE_PATH + FILES + QUESTION_MARK + Q + EQUAL + MIME_TYPE + EQUAL + APPLICATION + 
+            AND_SIGN + TRASH_FALSE + AND + PAGE_TOKEN + EQUAL + pageToken;
+        return drivePath;
+    }
+    drivePath = DRIVE_PATH + FILES + QUESTION_MARK + Q + EQUAL + MIME_TYPE + EQUAL + APPLICATION + AND_SIGN + 
+        TRASH_FALSE;
+    return drivePath;
+}
+
 # Create a random UUID removing the unnecessary hyphens which will interrupt querying opearations.
 # 
 # + return - A string UUID without hyphens


### PR DESCRIPTION
## Purpose
> 
This PR mainly solves the following issues.

The `getAllspreadsheets` remote operation returns trash files. 
Resolves https://github.com/wso2-enterprise/choreo/issues/4107
Resolves https://github.com/wso2-enterprise/choreo/issues/3493

In the current approach of getAllSpreadsheets method of Google sheets connector, we add all files in an array by doing recursive function calls and deliver to user as stream. There is a possibility of getting array out of memory error.
https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/blob/ee5a767b1f5b4554ea852db8b48b70490a11d102/gsheet/utils.bal#L122
Resolves https://github.com/wso2-enterprise/choreo/issues/4136

## Goals
> 

- Fix returning trash files in `getAllspreadsheets` remote operation. 
- Improve stream functionality of getAllSpreadsheets remote operation by using a stream implementer.

Please refer
https://github.com/ballerina-platform/module-ballerinax-googleapis.calendar/blob/a2a54c4ea2b1e12621cef1559e21e3388bbde029/calendar/endpoints.bal#L148
https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/a4e66d469c6d45162a9382cee1b0539628eef16b/client_endpoint.bal#L143

## Approach
> 
Modify the URL path by adding an optional parameter to avoid getting trash files. 
Improve stream functionality of getAllSpreadsheets remote operation by using a stream implementer.

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ubuntu 20.04
JDK 11
Swan Lake Alpha5
