### PR TITLE
Use separate token for github publishing

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -53,6 +53,8 @@ jobs:
               env:
                 packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
                 packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                publishPAT: ${{ secrets.CONNECTOR_PUBLISH_PAT }}
                 JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
               run: |
                 ./gradlew publish

--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/ballerina-platform/module-ballerinax-googleapis.sheets")
             credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
+                username = System.getenv("publishUser")
+                password = System.getenv("publishPAT")
             }
         }
     }


### PR DESCRIPTION
## Purpose
-  Fix https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/issues/148

## Goals
- Fix the publishing part of daily build

## Approach
- Use a separate token for publishing part which has scope to publish

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Swan Lake Beta1
