### PR TITLE
Fix http response type

### DIFF
--- a/gsheet/client.bal
+++ b/gsheet/client.bal
@@ -356,7 +356,7 @@ public client class Client {
         }
         json jsonPayload = {"values": jsonValues};
         request.setJsonPayload(<@untainted>jsonPayload);
-        var httpResponse = self.httpClient->put(<@untainted>setValuePath, request);
+        http:Response|error httpResponse = self.httpClient->put(<@untainted>setValuePath, request);
         if (httpResponse is http:Response) {
             int statusCode = httpResponse.statusCode;
             var jsonResponse = httpResponse.getJsonPayload();
@@ -1032,7 +1032,7 @@ public client class Client {
         string setCellDataPath = SPREADSHEET_PATH + PATH_SEPARATOR + spreadsheetId + VALUES_PATH + notatiob
         + QUESTION_MARK + VALUE_INPUT_OPTION;
         request.setJsonPayload(jsonPayload);
-        var httpResponse = self.httpClient->put(<@untainted>setCellDataPath, request);
+        http:Response|error httpResponse = self.httpClient->put(<@untainted>setCellDataPath, request);
         if (httpResponse is http:Response) {
             int statusCode = httpResponse.statusCode;
             var jsonResponse = httpResponse.getJsonPayload();

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -36,7 +36,7 @@ function testOnAppendRowTrigger() returns @tainted error? {
         "triggerUid":"6785380","user":{"email":"rolandh@wso2.com","nickname":"rolandh"}}};
     request.setPayload(payload);
 
-    var response = httpClient->post("/", request);
+    http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200);
     } else {
@@ -55,7 +55,7 @@ function testOnUpdateRowTrigger() returns @tainted error? {
         "user":{"email":"rolandh@wso2.com","nickname":"rolandh"},"value":"a"}};
     request.setPayload(payload);
 
-    var response = httpClient->post("/", request);
+    http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200);
     } else {

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -1,10 +1,9 @@
 import ballerina/http;
 import ballerina/log;
 import ballerina/test;
-import ballerina/os;
 
-configurable int port = 9090;
-configurable string spreadsheetId = os:getEnv("SPREADSHEET_ID");
+int port = 9090;
+string spreadsheetId = "1cBz31FboLUNyoyO_MK6vwGr6CJ9QDABbTAzIPsfyuqA";
 
 SheetListenerConfiguration congifuration = {
     port: port,
@@ -14,19 +13,26 @@ SheetListenerConfiguration congifuration = {
 listener Listener gsheetListener = new (congifuration);
 
 service / on gsheetListener {
-    isolated remote function onAppendRow(GSheetEvent event) returns error? {
+    isolated remote function onAppendRow(GSheetEvent event) {
         log:printInfo("Received onAppendRow-message ", eventMsg = event);
+        string? receivedData = event?.eventInfo?.spreadsheetName;
+        if (event?.eventInfo?.spreadsheetName != "TestListener") {
+            log:printError("Received event data doesn't match");
+        }
     }
 
-    isolated remote function onUpdateRow(GSheetEvent event) returns error? {
+    isolated remote function onUpdateRow(GSheetEvent event) {
         log:printInfo("Received onUpdateRow-message ", eventMsg = event);
+        if (event?.eventInfo?.spreadsheetName != "TestListener") {
+            log:printError("Received event data doesn't match");
+        }
     }
 }
 
 http:Client httpClient = checkpanic new("http://localhost:9090/onEdit");
 
 @test:Config {}
-function testOnAppendRowTrigger() returns @tainted error? {
+function testOnAppendRowTrigger() {
     http:Request request = new;
     json payload =  {"spreadsheetId":"1cBz31FboLUNyoyO_MK6vwGr6CJ9QDABbTAzIPsfyuqA","spreadsheetName":"TestListener",
         "worksheetId":0,"worksheetName":"Sheet1","rangeUpdated":"A6:C6","startingRowPosition":6,
@@ -45,7 +51,7 @@ function testOnAppendRowTrigger() returns @tainted error? {
 }
 
 @test:Config {}
-function testOnUpdateRowTrigger() returns @tainted error? {
+function testOnUpdateRowTrigger() {
     http:Request request = new;
     json payload =  {"spreadsheetId":"1cBz31FboLUNyoyO_MK6vwGr6CJ9QDABbTAzIPsfyuqA","spreadsheetName":"TestListener",
         "worksheetId":0,"worksheetName":"Sheet1","rangeUpdated":"B4","startingRowPosition":4,"startingColumnPosition":2,

--- a/gsheet/utils.bal
+++ b/gsheet/utils.bal
@@ -24,7 +24,7 @@ returns @tainted json | error {
     if (jsonPayload != ()) {
         httpRequest.setJsonPayload(<@untainted>jsonPayload);
     }
-    var httpResponse = httpClient->post(<@untainted>path, httpRequest);
+    http:Response|error httpResponse = httpClient->post(<@untainted>path, httpRequest);
     if (httpResponse is http:Response) {
         int statusCode = httpResponse.statusCode;
         json | http:ClientError jsonResponse = httpResponse.getJsonPayload();
@@ -43,7 +43,7 @@ returns @tainted json | error {
 }
 
 isolated function sendRequest(http:Client httpClient, string path) returns @tainted json | error {
-    var httpResponse = httpClient->get(<@untainted>path);
+    http:Response|error httpResponse = httpClient->get(<@untainted>path);
     if (httpResponse is http:Response) {
         int statusCode = httpResponse.statusCode;
         json | error jsonResponse = httpResponse.getJsonPayload();


### PR DESCRIPTION
## Purpose
> Change http response type as `http:Response' since 'var' is used earlier and is not supported in beta. Improve listener test logic.

## Goals
> Fix nightly build failure