### PR TITLE
Convert array return types to records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,8 +1048,8 @@ public function main() {
         string[] values = ["Update", "Column", "Values"];
         error? columnCreate = checkpanic spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
         // Gets the values in the given column in a Worksheet with given name.
-        (string|int|decimal)[]|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
-        if (column is (string|int|decimal)[]) {
+        sheets:Column|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
+        if (column is sheets:Column) {
             log:printInfo(column.toString());
         } else {
             log:printError("Error: " + column.toString());
@@ -1167,8 +1167,8 @@ public function main() {
         string[] values = ["Update", "Row", "Values"];
         error? rowCreate = checkpanic spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
         // Gets the values in the given row in a Worksheet with given name.
-        (string|int|decimal)[]|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
-        if (row is (string|int|decimal)[]) {
+        sheets:Row|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
+        if (row is sheets:Row) {
             log:printInfo(row.toString());
         } else {
             log:printError("Error: " + row.toString());
@@ -1264,8 +1264,8 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setCell(spreadsheetId, sheetName, a1Notation, "ModifiedValue");
     if (spreadsheetRes is ()) {
         // Gets the value of the given cell of the Sheet
-        (string|int|decimal)|error getValuesResult = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
-        if (getValuesResult is (string|int|decimal)) {
+        sheets:Cell|error getValuesResult = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
+        if (getValuesResult is sheets:Cell) {
             log:printInfo("Cell Details: " + getValuesResult.toString());
         } else {
             log:printError("Error: " + getValuesResult.toString());
@@ -1274,8 +1274,8 @@ public function main() {
         // Clears the given cell of contents, formats, and data validation rules.
         error? clear = spreadsheetClient->clearCell(spreadsheetId, sheetName, a1Notation);
         if (clear is ()) {
-            (string|int|decimal)|error openRes = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
-            if (openRes is (string|int|decimal)) {
+            sheets:Cell|error openRes = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
+            if (openRes is sheets:Cell) {
                 log:printInfo("Cell Details: " + openRes.toString());
             } else {
                 log:printError("Error: " + openRes.toString());
@@ -1300,7 +1300,7 @@ To clear the value of the given cell of the Worksheet, we must specify the sprea
 
 
 ### Append Row to Sheet
-This section shows how to use the Google Spreadsheet ballerina connector Append a new row with the given values to the bottom in a Worksheet with given name to the spreadsheet with the given spreadsheet ID. We must specify the spreadsheet ID and the name for the new worksheet as string parameters and row values as an array of (int|string|float), to the appendRowToSheet remote operation. Spreadsheet ID is available in the spreadsheet URL "https://docs.google.com/spreadsheets/d/" + <spreadsheetId> + "/edit#gid=" + <sheetId>. This is the basic scenario of appending a new row with the given values to the bottom in a Worksheet with the name obtained when creating a new worksheet and by the spreadsheet ID which is obtained when creating a new spreadsheet. It returns Nil on success and a ballerina error if the operation is unsuccessful. 
+This section shows how to use the Google Spreadsheet ballerina connector Append a new row with the given values to the bottom in a Worksheet with given name to the spreadsheet with the given spreadsheet ID. We must specify the spreadsheet ID and the name for the new worksheet as string parameters and row values as an array of (int|string|decimal), to the appendRowToSheet remote operation. Spreadsheet ID is available in the spreadsheet URL "https://docs.google.com/spreadsheets/d/" + <spreadsheetId> + "/edit#gid=" + <sheetId>. This is the basic scenario of appending a new row with the given values to the bottom in a Worksheet with the name obtained when creating a new worksheet and by the spreadsheet ID which is obtained when creating a new spreadsheet. It returns Nil on success and a ballerina error if the operation is unsuccessful. 
 
 Sample is available at:
 https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/blob/slalpha5/gsheet/samples/appendRowToSheet.bal

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
  
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 ```
 Then the endpoint actions can be invoked as `var response = spreadsheetClient->actionName(arguments)`.
 
@@ -171,7 +171,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
 public function main(string... args) {
     var response = spreadsheetClient->openSpreadsheetById(<spreadsheet-id>);
@@ -203,7 +203,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
 public function main(string... args) {
     var response = spreadsheetClient->openSpreadsheetById(<spreadsheet-id>);
@@ -247,7 +247,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
  
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 ```
 
 ### Step 3: Create Spreadsheet with given name
@@ -368,9 +368,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     // Create Spreadsheet with given name
     sheets:Spreadsheet|error response = spreadsheetClient->createSpreadsheet("NewSpreadsheet");
     if (response is sheets:Spreadsheet) {
@@ -400,9 +400,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -444,9 +444,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -488,9 +488,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -538,9 +538,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
 
     // Get All Spreadsheets associated with the user account
     stream<sheets:File>|error response = spreadsheetClient->getAllSpreadsheets();
@@ -577,9 +577,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -620,9 +620,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -673,9 +673,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -731,9 +731,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     int sheetId = 0;
 
@@ -789,9 +789,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -847,9 +847,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -906,9 +906,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -997,9 +997,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1037,16 +1037,16 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Inserts the given number of columns before the given column position in a Worksheet with given ID.
-        error? columnBeforeId = checkpanic spreadsheetClient->addColumnsBefore(spreadsheetId, sheetId, 3, 1);
+        error? columnBeforeId = check spreadsheetClient->addColumnsBefore(spreadsheetId, sheetId, 3, 1);
         // Inserts the given number of columns before the given column position in a Worksheet with given name.
-        error? columnBefore = checkpanic spreadsheetClient->addColumnsBeforeBySheetName(spreadsheetId, sheetName, 4, 1);        
+        error? columnBefore = check spreadsheetClient->addColumnsBeforeBySheetName(spreadsheetId, sheetName, 4, 1);        
         // Inserts the given number of columns after the given column position in a Worksheet with given ID.
-        error? columnAfterId = checkpanic spreadsheetClient->addColumnsAfter(spreadsheetId, sheetId, 5, 1);
+        error? columnAfterId = check spreadsheetClient->addColumnsAfter(spreadsheetId, sheetId, 5, 1);
         // Inserts the given number of columns after the given column position in a Worksheet with given name.
-        error? columnAfter = checkpanic spreadsheetClient->addColumnsAfterBySheetName(spreadsheetId, sheetName, 6, 1);
+        error? columnAfter = check spreadsheetClient->addColumnsAfterBySheetName(spreadsheetId, sheetName, 6, 1);
         // Create or Update a Column with the given array of values in a Worksheet with given name.
         string[] values = ["Update", "Column", "Values"];
-        error? columnCreate = checkpanic spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
+        error? columnCreate = check spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
         // Gets the values in the given column in a Worksheet with given name.
         sheets:Column|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
         if (column is sheets:Column) {
@@ -1055,9 +1055,9 @@ public function main() {
             log:printError("Error: " + column.toString());
         }
         // Deletes the given number of columns starting at the given column position in a Worksheet with given ID.
-        error? columnDeleteId = checkpanic spreadsheetClient->deleteColumns(spreadsheetId, sheetId, 3, 2);
+        error? columnDeleteId = check spreadsheetClient->deleteColumns(spreadsheetId, sheetId, 3, 2);
         // Deletes the given number of columns starting at the given column position in a Worksheet with given name.
-        error? columnDelete = checkpanic spreadsheetClient->deleteColumnsBySheetName(spreadsheetId, sheetName, 4, 2);
+        error? columnDelete = check spreadsheetClient->deleteColumnsBySheetName(spreadsheetId, sheetName, 4, 2);
 
         // Gets the given range of the Sheet
         sheets:Range|error getValuesResult = spreadsheetClient->getRange(spreadsheetId, sheetName, a1Notation);
@@ -1116,9 +1116,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1156,16 +1156,16 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Inserts the given number of rows before the given row position in a Worksheet with given ID.
-        error? rowBeforeId = checkpanic spreadsheetClient->addRowsBefore(spreadsheetId, sheetId, 4, 1);
+        error? rowBeforeId = check spreadsheetClient->addRowsBefore(spreadsheetId, sheetId, 4, 1);
         // Inserts the given number of rows before the given row position in a Worksheet with given name.
-        error? rowBefore = checkpanic spreadsheetClient->addRowsBeforeBySheetName(spreadsheetId, sheetName, 5, 1);        
+        error? rowBefore = check spreadsheetClient->addRowsBeforeBySheetName(spreadsheetId, sheetName, 5, 1);        
         // Inserts the given number of rows after the given row position in a Worksheet with given ID.
-        error? rowAfterId = checkpanic spreadsheetClient->addRowsAfter(spreadsheetId, sheetId, 6, 1);
+        error? rowAfterId = check spreadsheetClient->addRowsAfter(spreadsheetId, sheetId, 6, 1);
         // Inserts the given number of rows after the given row position in a Worksheet with given name.
-        error? rowAfter = checkpanic spreadsheetClient->addRowsAfterBySheetName(spreadsheetId, sheetName, 7, 1);
+        error? rowAfter = check spreadsheetClient->addRowsAfterBySheetName(spreadsheetId, sheetName, 7, 1);
         // Create or Update a Row with the given array of values in a Worksheet with given name.
         string[] values = ["Update", "Row", "Values"];
-        error? rowCreate = checkpanic spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
+        error? rowCreate = check spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
         // Gets the values in the given row in a Worksheet with given name.
         sheets:Row|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
         if (row is sheets:Row) {
@@ -1174,9 +1174,9 @@ public function main() {
             log:printError("Error: " + row.toString());
         }
         // Deletes the given number of rows starting at the given row position in a Worksheet with given ID.
-        error? rowDeleteId = checkpanic spreadsheetClient->deleteRows(spreadsheetId, sheetId, 4, 2);
+        error? rowDeleteId = check spreadsheetClient->deleteRows(spreadsheetId, sheetId, 4, 2);
         // Deletes the given number of rows starting at the given row position in a Worksheet with given name.
-        error? rowDelete = checkpanic spreadsheetClient->deleteRowsBySheetName(spreadsheetId, sheetName, 5, 2);
+        error? rowDelete = check spreadsheetClient->deleteRowsBySheetName(spreadsheetId, sheetName, 5, 2);
 
         // Gets the given range of the Sheet
         sheets:Range|error getValuesResult = spreadsheetClient->getRange(spreadsheetId, sheetName, a1Notation);
@@ -1234,9 +1234,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -1318,9 +1318,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1359,9 +1359,9 @@ public function main() {
     if (spreadsheetRes is ()) {
         // Append a new row with the given values to the bottom in a Worksheet with given name. 
         string[] values = ["Appending", "Some", "Values"];
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values);
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values);
         string[] valuesNext = ["Appending", "Another", "Row"];
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext);
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D7";
@@ -1396,9 +1396,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1439,9 +1439,9 @@ public function main() {
         // The input range is used to search for existing data and find a "table" within that range. Values are appended 
         // to the next row of the table, starting with the first column of the table.
         string[] values = ["Appending", "Some", "Values"];
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values, "A2");
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values, "A2");
         string[] valuesNext = ["Appending", "Another", "Row"];
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext, a1Notation);
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext, a1Notation);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "B2:E8";
@@ -1476,9 +1476,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1519,8 +1519,8 @@ public function main() {
         // The input range is used to search for existing data and find a "table" within that range. Value is appended 
         // to the next row of the table, starting with the first column of the table. If the range is not in any table 
         // the value is written to the given cell
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value1"], "D6");
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value2"], a1Notation);
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value1"], "D6");
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value2"], a1Notation);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "B2:E8";
@@ -1555,9 +1555,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1632,9 +1632,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1709,9 +1709,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1749,7 +1749,7 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Clears the sheet content and formatting rules by worksheet Id.
-        error? clearAll = checkpanic spreadsheetClient->clearAll(spreadsheetId, sheetId);
+        error? clearAll = check spreadsheetClient->clearAll(spreadsheetId, sheetId);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D5";
@@ -1784,9 +1784,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1824,7 +1824,7 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Clears the sheet content and formatting rules by worksheet Name.
-        error? clearAll = checkpanic spreadsheetClient->clearAllBySheetName(spreadsheetId, sheetName);
+        error? clearAll = check spreadsheetClient->clearAllBySheetName(spreadsheetId, sheetName);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D5";

--- a/gsheet/Module.md
+++ b/gsheet/Module.md
@@ -117,7 +117,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 ```
 Then the endpoint actions can be invoked as `var response = spreadsheetClient->actionName(arguments)`.
 
@@ -135,7 +135,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
 public function main(string... args) {
     var response = spreadsheetClient->openSpreadsheetById(<spreadsheet-id>);
@@ -167,7 +167,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
 public function main(string... args) {
     var response = spreadsheetClient->openSpreadsheetById(<spreadsheet-id>);

--- a/gsheet/Package.md
+++ b/gsheet/Package.md
@@ -117,7 +117,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 ```
 Then the endpoint actions can be invoked as `var response = spreadsheetClient->actionName(arguments)`.
 
@@ -135,7 +135,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
 public function main(string... args) {
     var response = spreadsheetClient->openSpreadsheetById(<spreadsheet-id>);
@@ -167,7 +167,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
 public function main(string... args) {
     var response = spreadsheetClient->openSpreadsheetById(<spreadsheet-id>);

--- a/gsheet/client.bal
+++ b/gsheet/client.bal
@@ -616,13 +616,13 @@ public client class Client {
     # + valueRenderOption - Determines how values should be rendered in the output.
     #                       It's either "FORMATTED_VALUE","UNFORMATTED_VALUE" or "USER_ENTERED". 
     #                       Default is "FORMATTED_VALUE" (Optional)
-    # + return - Values of the given column in an array on success, else returns an error
+    # + return - Column record on success, else returns an error
     @display {label: "Get Column"}
     remote isolated function getColumn(@display {label: "Spreadsheet Id"} string spreadsheetId, 
                                        @display {label: "Worksheet Name"} string sheetName, 
                                        @display {label: "Column Position"} string column,
                                        @display {label: "Value Render Option"} string? valueRenderOption = ()) 
-                                       returns @tainted @display {label: "Column Values"} (string|int|decimal)[]|error {
+                                       returns @tainted Column|error {
         (int|string|decimal)[] values = [];
         string a1Notation = sheetName + EXCLAMATION_MARK + column + COLON + column;
         string getColumnDataPath = SPREADSHEET_PATH + PATH_SEPARATOR + spreadsheetId + VALUES_PATH + a1Notation;
@@ -649,7 +649,8 @@ public client class Client {
                     i = i + 1;
                 }
             }
-            return values;
+            Column columnRecord = {columnPosition: column, values: values};
+            return columnRecord;
         }
     }
 
@@ -924,13 +925,13 @@ public client class Client {
     # + valueRenderOption - Determines how values should be rendered in the output.
     #                       It's either "FORMATTED_VALUE","UNFORMATTED_VALUE" or "USER_ENTERED". 
     #                       Default is "FORMATTED_VALUE" (Optional)
-    # + return - Values of the given row in an array on success, else returns an error
+    # + return - Row record on success, else returns an error
     @display {label: "Get Row"}
     remote isolated function getRow(@display {label: "Spreadsheet Id"} string spreadsheetId, 
                                     @display {label: "Worksheet Name"} string sheetName, 
                                     @display {label: "Row Position"} int row,
                                     @display {label: "Value Render Option"} string? valueRenderOption = ()) 
-                                    returns @tainted @display {label: "Row Values"} (string|int|decimal)[]|error {
+                                    returns @tainted Row|error {
         (int|string|decimal)[] values = [];
         string a1Notation = sheetName + EXCLAMATION_MARK + row.toString() + COLON + row.toString();
         string getRowDataPath = SPREADSHEET_PATH + PATH_SEPARATOR + spreadsheetId + VALUES_PATH + a1Notation;
@@ -953,7 +954,8 @@ public client class Client {
                     i = i + 1;
                 }
             }
-            return values;
+            Row rowRecord = {rowPosition: row, values: values};
+            return rowRecord;
         }
     }
 
@@ -1075,13 +1077,13 @@ public client class Client {
     # + valueRenderOption - Determines how values should be rendered in the output.
     #                       It's either "FORMATTED_VALUE","UNFORMATTED_VALUE" or "USER_ENTERED". 
     #                       Default is "FORMATTED_VALUE" (Optional)
-    # + return - Value of the given cell on success, else returns an error
+    # + return - Cell record on success, else returns an error
     @display {label: "Get Cell"}
     remote isolated function getCell(@display {label: "Spreadsheet Id"} string spreadsheetId, 
                                      @display {label: "Worksheet Name"} string sheetName, 
                                      @display {label: "Cell A1 Notation"} string a1Notation,
                                      @display {label: "Value Render Option"} string? valueRenderOption = ()) 
-                                     returns @tainted @display {label: "Cell Value"} int|string|decimal|error {
+                                     returns @tainted Cell|error {
         int|string|decimal value = EMPTY_STRING;
         string notation = sheetName + EXCLAMATION_MARK + a1Notation;
         string getCellDataPath = SPREADSHEET_PATH + PATH_SEPARATOR + spreadsheetId + VALUES_PATH + notation;
@@ -1100,7 +1102,8 @@ public client class Client {
                 json[] firstResponseValue = <json[]>responseValues[0];
                 value = getConvertedValue(firstResponseValue[0]);
             }
-            return value;
+            Cell cellRecord = {a1Notation: a1Notation, value: value};
+            return cellRecord;
         }
     }
 
@@ -1132,7 +1135,7 @@ public client class Client {
     @display {label: "Append Row"}
     remote isolated function appendRowToSheet(@display {label: "Spreadsheet Id"} string spreadsheetId, 
                                               @display {label: "Worksheet Name"} string sheetName, 
-                                              @display {label: "Row Values"} (int|string|float)[] values,
+                                              @display {label: "Row Values"} (int|string|decimal)[] values,
                                               @display {label: "Range A1 Notation"} string? a1Notation = (),
                                               @display {label: "Value Input Option"} string? valueInputOption = ()) 
                                               returns @tainted error? {
@@ -1143,7 +1146,7 @@ public client class Client {
             string `${VALUE_INPUT_OPTION}${valueInputOption}`);
         json[] jsonValues = [];
         int i = 0;
-        foreach (string|int|float) value in values {
+        foreach (string|int|decimal) value in values {
             jsonValues[i] = value;
             i = i + 1;
         }

--- a/gsheet/metadata/google_sheet.json
+++ b/gsheet/metadata/google_sheet.json
@@ -434,8 +434,8 @@
                             }
                         ],
                         "returnValue": {
-                            "name": "(string | int | float)[]",
-                            "displayName": "Values in Column"
+                            "name": "Column",
+                            "displayName": "Column"
                         }
         
                     },
@@ -646,8 +646,8 @@
                             }
                         ],
                         "returnValue": {
-                            "name": "(string | int | float)[]",
-                            "displayName": "Values in Row"
+                            "name": "Row",
+                            "displayName": "Row"
                         }
         
                     },
@@ -750,8 +750,8 @@
                             }
                         ],
                         "returnValue": {
-                            "name": "int | string | float",
-                            "displayName": "Value"
+                            "name": "Cell",
+                            "displayName": "Cell"
                         }
         
                     },
@@ -791,7 +791,7 @@
                                 "displayName": "Sheet Name"
                             },
                             {
-                                "name": "(int | string | float)[]",
+                                "name": "(int | string | decimal)[]",
                                 "displayName": "Values for New Row"
                             }
                         ],

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -29,7 +29,7 @@ service / on gsheetListener {
     }
 }
 
-http:Client httpClient = checkpanic new("http://localhost:9090/onEdit");
+http:Client httpClient = check new("http://localhost:9090/onEdit");
 
 @test:Config {}
 function testOnAppendRowTrigger() {

--- a/gsheet/samples/README.md
+++ b/gsheet/samples/README.md
@@ -26,9 +26,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     // Create Spreadsheet with given name
     sheets:Spreadsheet|error response = spreadsheetClient->createSpreadsheet("NewSpreadsheet");
     if (response is sheets:Spreadsheet) {
@@ -63,9 +63,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -111,9 +111,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -159,9 +159,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -213,9 +213,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
 
     // Get All Spreadsheets associated with the user account
     stream<sheets:File>|error response = spreadsheetClient->getAllSpreadsheets();
@@ -257,9 +257,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name
@@ -304,9 +304,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -361,9 +361,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -423,9 +423,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     int sheetId = 0;
 
@@ -485,9 +485,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -547,9 +547,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -609,9 +609,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -704,9 +704,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -744,16 +744,16 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Inserts the given number of columns before the given column position in a Worksheet with given ID.
-        error? columnBeforeId = checkpanic spreadsheetClient->addColumnsBefore(spreadsheetId, sheetId, 3, 1);
+        error? columnBeforeId = check spreadsheetClient->addColumnsBefore(spreadsheetId, sheetId, 3, 1);
         // Inserts the given number of columns before the given column position in a Worksheet with given name.
-        error? columnBefore = checkpanic spreadsheetClient->addColumnsBeforeBySheetName(spreadsheetId, sheetName, 4, 1);        
+        error? columnBefore = check spreadsheetClient->addColumnsBeforeBySheetName(spreadsheetId, sheetName, 4, 1);        
         // Inserts the given number of columns after the given column position in a Worksheet with given ID.
-        error? columnAfterId = checkpanic spreadsheetClient->addColumnsAfter(spreadsheetId, sheetId, 5, 1);
+        error? columnAfterId = check spreadsheetClient->addColumnsAfter(spreadsheetId, sheetId, 5, 1);
         // Inserts the given number of columns after the given column position in a Worksheet with given name.
-        error? columnAfter = checkpanic spreadsheetClient->addColumnsAfterBySheetName(spreadsheetId, sheetName, 6, 1);
+        error? columnAfter = check spreadsheetClient->addColumnsAfterBySheetName(spreadsheetId, sheetName, 6, 1);
         // Create or Update a Column with the given array of values in a Worksheet with given name.
         string[] values = ["Update", "Column", "Values"];
-        error? columnCreate = checkpanic spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
+        error? columnCreate = check spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
         // Gets the values in the given column in a Worksheet with given name.
         sheets:Column|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
         if (column is sheets:Column) {
@@ -762,9 +762,9 @@ public function main() {
             log:printError("Error: " + column.toString());
         }
         // Deletes the given number of columns starting at the given column position in a Worksheet with given ID.
-        error? columnDeleteId = checkpanic spreadsheetClient->deleteColumns(spreadsheetId, sheetId, 3, 2);
+        error? columnDeleteId = check spreadsheetClient->deleteColumns(spreadsheetId, sheetId, 3, 2);
         // Deletes the given number of columns starting at the given column position in a Worksheet with given name.
-        error? columnDelete = checkpanic spreadsheetClient->deleteColumnsBySheetName(spreadsheetId, sheetName, 4, 2);
+        error? columnDelete = check spreadsheetClient->deleteColumnsBySheetName(spreadsheetId, sheetName, 4, 2);
 
         // Gets the given range of the Sheet
         sheets:Range|error getValuesResult = spreadsheetClient->getRange(spreadsheetId, sheetName, a1Notation);
@@ -827,9 +827,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -867,16 +867,16 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Inserts the given number of rows before the given row position in a Worksheet with given ID.
-        error? rowBeforeId = checkpanic spreadsheetClient->addRowsBefore(spreadsheetId, sheetId, 4, 1);
+        error? rowBeforeId = check spreadsheetClient->addRowsBefore(spreadsheetId, sheetId, 4, 1);
         // Inserts the given number of rows before the given row position in a Worksheet with given name.
-        error? rowBefore = checkpanic spreadsheetClient->addRowsBeforeBySheetName(spreadsheetId, sheetName, 5, 1);        
+        error? rowBefore = check spreadsheetClient->addRowsBeforeBySheetName(spreadsheetId, sheetName, 5, 1);        
         // Inserts the given number of rows after the given row position in a Worksheet with given ID.
-        error? rowAfterId = checkpanic spreadsheetClient->addRowsAfter(spreadsheetId, sheetId, 6, 1);
+        error? rowAfterId = check spreadsheetClient->addRowsAfter(spreadsheetId, sheetId, 6, 1);
         // Inserts the given number of rows after the given row position in a Worksheet with given name.
-        error? rowAfter = checkpanic spreadsheetClient->addRowsAfterBySheetName(spreadsheetId, sheetName, 7, 1);
+        error? rowAfter = check spreadsheetClient->addRowsAfterBySheetName(spreadsheetId, sheetName, 7, 1);
         // Create or Update a Row with the given array of values in a Worksheet with given name.
         string[] values = ["Update", "Row", "Values"];
-        error? rowCreate = checkpanic spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
+        error? rowCreate = check spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
         // Gets the values in the given row in a Worksheet with given name.
         sheets:Row|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
         if (row is sheets:Row) {
@@ -885,9 +885,9 @@ public function main() {
             log:printError("Error: " + row.toString());
         }
         // Deletes the given number of rows starting at the given row position in a Worksheet with given ID.
-        error? rowDeleteId = checkpanic spreadsheetClient->deleteRows(spreadsheetId, sheetId, 4, 2);
+        error? rowDeleteId = check spreadsheetClient->deleteRows(spreadsheetId, sheetId, 4, 2);
         // Deletes the given number of rows starting at the given row position in a Worksheet with given name.
-        error? rowDelete = checkpanic spreadsheetClient->deleteRowsBySheetName(spreadsheetId, sheetName, 5, 2);
+        error? rowDelete = check spreadsheetClient->deleteRowsBySheetName(spreadsheetId, sheetName, 5, 2);
 
         // Gets the given range of the Sheet
         sheets:Range|error getValuesResult = spreadsheetClient->getRange(spreadsheetId, sheetName, a1Notation);
@@ -949,9 +949,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 
@@ -1037,9 +1037,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1078,9 +1078,9 @@ public function main() {
     if (spreadsheetRes is ()) {
         // Append a new row with the given values to the bottom in a Worksheet with given name. 
         string[] values = ["Appending", "Some", "Values"];
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values);
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values);
         string[] valuesNext = ["Appending", "Another", "Row"];
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext);
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D7";
@@ -1119,9 +1119,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1162,9 +1162,9 @@ public function main() {
         // The input range is used to search for existing data and find a "table" within that range. Values are appended 
         // to the next row of the table, starting with the first column of the table.
         string[] values = ["Appending", "Some", "Values"];
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values, "A2");
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values, "A2");
         string[] valuesNext = ["Appending", "Another", "Row"];
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext, a1Notation);
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext, a1Notation);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "B2:E8";
@@ -1203,9 +1203,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1246,8 +1246,8 @@ public function main() {
         // The input range is used to search for existing data and find a "table" within that range. Value is appended 
         // to the next row of the table, starting with the first column of the table. If the range is not in any table 
         // the value is written to the given cell
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value1"], "D6");
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value2"], a1Notation);
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value1"], "D6");
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value2"], a1Notation);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "B2:E8";
@@ -1286,9 +1286,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1367,9 +1367,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1448,9 +1448,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1488,7 +1488,7 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Clears the sheet content and formatting rules by worksheet Id.
-        error? clearAll = checkpanic spreadsheetClient->clearAll(spreadsheetId, sheetId);
+        error? clearAll = check spreadsheetClient->clearAll(spreadsheetId, sheetId);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D5";
@@ -1527,9 +1527,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -1567,7 +1567,7 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Clears the sheet content and formatting rules by worksheet Name.
-        error? clearAll = checkpanic spreadsheetClient->clearAllBySheetName(spreadsheetId, sheetName);
+        error? clearAll = check spreadsheetClient->clearAllBySheetName(spreadsheetId, sheetName);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D5";

--- a/gsheet/samples/README.md
+++ b/gsheet/samples/README.md
@@ -755,8 +755,8 @@ public function main() {
         string[] values = ["Update", "Column", "Values"];
         error? columnCreate = checkpanic spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
         // Gets the values in the given column in a Worksheet with given name.
-        (string|int|decimal)[]|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
-        if (column is (string|int|decimal)[]) {
+        sheets:Column|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
+        if (column is sheets:Column) {
             log:printInfo(column.toString());
         } else {
             log:printError("Error: " + column.toString());
@@ -878,8 +878,8 @@ public function main() {
         string[] values = ["Update", "Row", "Values"];
         error? rowCreate = checkpanic spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
         // Gets the values in the given row in a Worksheet with given name.
-        (string|int|decimal)[]|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
-        if (row is (string|int|decimal)[]) {
+        sheets:Row|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
+        if (row is sheets:Row) {
             log:printInfo(row.toString());
         } else {
             log:printError("Error: " + row.toString());
@@ -979,8 +979,8 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setCell(spreadsheetId, sheetName, a1Notation, "ModifiedValue");
     if (spreadsheetRes is ()) {
         // Gets the value of the given cell of the Sheet
-        (string|int|decimal)|error getValuesResult = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
-        if (getValuesResult is (string|int|decimal)) {
+        sheets:Cell|error getValuesResult = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
+        if (getValuesResult is sheets:Cell) {
             log:printInfo("Cell Details: " + getValuesResult.toString());
         } else {
             log:printError("Error: " + getValuesResult.toString());
@@ -989,8 +989,8 @@ public function main() {
         // Clears the given cell of contents, formats, and data validation rules.
         error? clear = spreadsheetClient->clearCell(spreadsheetId, sheetName, a1Notation);
         if (clear is ()) {
-            (string|int|decimal)|error openRes = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
-            if (openRes is (string|int|decimal)) {
+            sheets:Cell|error openRes = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
+            if (openRes is sheets:Cell) {
                 log:printInfo("Cell Details: " + openRes.toString());
             } else {
                 log:printError("Error: " + openRes.toString());
@@ -1015,7 +1015,7 @@ To clear the value of the given cell of the Worksheet, we must specify the sprea
 
 
 ### Append Row to Sheet
-This section shows how to use the Google Spreadsheet ballerina connector Append a new row with the given values to the bottom in a Worksheet with given name to the spreadsheet with the given spreadsheet ID. We must specify the spreadsheet ID and the name for the new worksheet as string parameters and row values as an array of (int|string|float), to the appendRowToSheet remote operation. Spreadsheet ID is available in the spreadsheet URL "https://docs.google.com/spreadsheets/d/" + <spreadsheetId> + "/edit#gid=" + <sheetId>. This is the basic scenario of appending a new row with the given values to the bottom in a Worksheet with the name obtained when creating a new worksheet and by the spreadsheet ID which is obtained when creating a new spreadsheet. It returns Nil on success and a ballerina error if the operation is unsuccessful. 
+This section shows how to use the Google Spreadsheet ballerina connector Append a new row with the given values to the bottom in a Worksheet with given name to the spreadsheet with the given spreadsheet ID. We must specify the spreadsheet ID and the name for the new worksheet as string parameters and row values as an array of (int|string|decimal), to the appendRowToSheet remote operation. Spreadsheet ID is available in the spreadsheet URL "https://docs.google.com/spreadsheets/d/" + <spreadsheetId> + "/edit#gid=" + <sheetId>. This is the basic scenario of appending a new row with the given values to the bottom in a Worksheet with the name obtained when creating a new worksheet and by the spreadsheet ID which is obtained when creating a new spreadsheet. It returns Nil on success and a ballerina error if the operation is unsuccessful. 
 
 Sample is available at:
 https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/blob/slalpha5/gsheet/samples/appendRowToSheet.bal

--- a/gsheet/samples/addSheet.bal
+++ b/gsheet/samples/addSheet.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name

--- a/gsheet/samples/appendCellToRange.bal
+++ b/gsheet/samples/appendCellToRange.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -73,8 +73,8 @@ public function main() {
         // The input range is used to search for existing data and find a "table" within that range. Value is appended 
         // to the next row of the table, starting with the first column of the table. If the range is not in any table 
         // the value is written to the given cell
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value1"], "D6");
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value2"], a1Notation);
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value1"], "D6");
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, ["Modified Value2"], a1Notation);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "B2:E8";

--- a/gsheet/samples/appendRowToRange.bal
+++ b/gsheet/samples/appendRowToRange.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -73,9 +73,9 @@ public function main() {
         // The input range is used to search for existing data and find a "table" within that range. Values are appended 
         // to the next row of the table, starting with the first column of the table.
         string[] values = ["Appending", "Some", "Values"];
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values, "A2");
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values, "A2");
         string[] valuesNext = ["Appending", "Another", "Row"];
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext, a1Notation);
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext, a1Notation);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "B2:E8";

--- a/gsheet/samples/appendRowToSheet.bal
+++ b/gsheet/samples/appendRowToSheet.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -71,9 +71,9 @@ public function main() {
     if (spreadsheetRes is ()) {
         // Append a new row with the given values to the bottom in a Worksheet with given name. 
         string[] values = ["Appending", "Some", "Values"];
-        error? append = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values);
+        error? append = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, values);
         string[] valuesNext = ["Appending", "Another", "Row"];
-        error? appendNext = checkpanic spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext);
+        error? appendNext = check spreadsheetClient->appendRowToSheet(spreadsheetId, sheetName, valuesNext);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D7";

--- a/gsheet/samples/cell.bal
+++ b/gsheet/samples/cell.bal
@@ -60,8 +60,8 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setCell(spreadsheetId, sheetName, a1Notation, "ModifiedValue");
     if (spreadsheetRes is ()) {
         // Gets the value of the given cell of the Sheet
-        (string|int|decimal)|error getValuesResult = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
-        if (getValuesResult is (string|int|decimal)) {
+        sheets:Cell|error getValuesResult = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
+        if (getValuesResult is sheets:Cell) {
             log:printInfo("Cell Details: " + getValuesResult.toString());
         } else {
             log:printError("Error: " + getValuesResult.toString());
@@ -70,8 +70,8 @@ public function main() {
         // Clears the given cell of contents, formats, and data validation rules.
         error? clear = spreadsheetClient->clearCell(spreadsheetId, sheetName, a1Notation);
         if (clear is ()) {
-            (string|int|decimal)|error openRes = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
-            if (openRes is (string|int|decimal)) {
+            sheets:Cell|error openRes = spreadsheetClient->getCell(spreadsheetId, sheetName, a1Notation);
+            if (openRes is sheets:Cell) {
                 log:printInfo("Cell Details: " + openRes.toString());
             } else {
                 log:printError("Error: " + openRes.toString());

--- a/gsheet/samples/cell.bal
+++ b/gsheet/samples/cell.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 

--- a/gsheet/samples/clearAllById.bal
+++ b/gsheet/samples/clearAllById.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -70,7 +70,7 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Clears the sheet content and formatting rules by worksheet Id.
-        error? clearAll = checkpanic spreadsheetClient->clearAll(spreadsheetId, sheetId);
+        error? clearAll = check spreadsheetClient->clearAll(spreadsheetId, sheetId);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D5";

--- a/gsheet/samples/clearAllByName.bal
+++ b/gsheet/samples/clearAllByName.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -70,7 +70,7 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Clears the sheet content and formatting rules by worksheet Name.
-        error? clearAll = checkpanic spreadsheetClient->clearAllBySheetName(spreadsheetId, sheetName);
+        error? clearAll = check spreadsheetClient->clearAllBySheetName(spreadsheetId, sheetName);
 
         // Gets the given range of the Sheet
         string a1NotationAppend = "A1:D5";

--- a/gsheet/samples/column.bal
+++ b/gsheet/samples/column.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -70,16 +70,16 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Inserts the given number of columns before the given column position in a Worksheet with given ID.
-        error? columnBeforeId = checkpanic spreadsheetClient->addColumnsBefore(spreadsheetId, sheetId, 3, 1);
+        error? columnBeforeId = check spreadsheetClient->addColumnsBefore(spreadsheetId, sheetId, 3, 1);
         // Inserts the given number of columns before the given column position in a Worksheet with given name.
-        error? columnBefore = checkpanic spreadsheetClient->addColumnsBeforeBySheetName(spreadsheetId, sheetName, 4, 1);        
+        error? columnBefore = check spreadsheetClient->addColumnsBeforeBySheetName(spreadsheetId, sheetName, 4, 1);        
         // Inserts the given number of columns after the given column position in a Worksheet with given ID.
-        error? columnAfterId = checkpanic spreadsheetClient->addColumnsAfter(spreadsheetId, sheetId, 5, 1);
+        error? columnAfterId = check spreadsheetClient->addColumnsAfter(spreadsheetId, sheetId, 5, 1);
         // Inserts the given number of columns after the given column position in a Worksheet with given name.
-        error? columnAfter = checkpanic spreadsheetClient->addColumnsAfterBySheetName(spreadsheetId, sheetName, 6, 1);
+        error? columnAfter = check spreadsheetClient->addColumnsAfterBySheetName(spreadsheetId, sheetName, 6, 1);
         // Create or Update a Column with the given array of values in a Worksheet with given name.
         string[] values = ["Update", "Column", "Values"];
-        error? columnCreate = checkpanic spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
+        error? columnCreate = check spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
         // Gets the values in the given column in a Worksheet with given name.
         sheets:Column|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
         if (column is sheets:Column) {
@@ -88,9 +88,9 @@ public function main() {
             log:printError("Error: " + column.toString());
         }
         // Deletes the given number of columns starting at the given column position in a Worksheet with given ID.
-        error? columnDeleteId = checkpanic spreadsheetClient->deleteColumns(spreadsheetId, sheetId, 3, 2);
+        error? columnDeleteId = check spreadsheetClient->deleteColumns(spreadsheetId, sheetId, 3, 2);
         // Deletes the given number of columns starting at the given column position in a Worksheet with given name.
-        error? columnDelete = checkpanic spreadsheetClient->deleteColumnsBySheetName(spreadsheetId, sheetName, 4, 2);
+        error? columnDelete = check spreadsheetClient->deleteColumnsBySheetName(spreadsheetId, sheetName, 4, 2);
 
         // Gets the given range of the Sheet
         sheets:Range|error getValuesResult = spreadsheetClient->getRange(spreadsheetId, sheetName, a1Notation);

--- a/gsheet/samples/column.bal
+++ b/gsheet/samples/column.bal
@@ -81,8 +81,8 @@ public function main() {
         string[] values = ["Update", "Column", "Values"];
         error? columnCreate = checkpanic spreadsheetClient->createOrUpdateColumn(spreadsheetId, sheetName, "I", values);
         // Gets the values in the given column in a Worksheet with given name.
-        (string|int|decimal)[]|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
-        if (column is (string|int|decimal)[]) {
+        sheets:Column|error column = spreadsheetClient->getColumn(spreadsheetId, sheetName, "I");
+        if (column is sheets:Column) {
             log:printInfo(column.toString());
         } else {
             log:printError("Error: " + column.toString());

--- a/gsheet/samples/copyToById.bal
+++ b/gsheet/samples/copyToById.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;

--- a/gsheet/samples/copyToByName.bal
+++ b/gsheet/samples/copyToByName.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;

--- a/gsheet/samples/createSpreadsheet.bal
+++ b/gsheet/samples/createSpreadsheet.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     // Create Spreadsheet with given name
     sheets:Spreadsheet|error response = spreadsheetClient->createSpreadsheet("NewSpreadsheet");
     if (response is sheets:Spreadsheet) {

--- a/gsheet/samples/getAllSpreadsheets.bal
+++ b/gsheet/samples/getAllSpreadsheets.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
 
     // Get All Spreadsheets associated with the user account
     stream<sheets:File,error>|error response = spreadsheetClient->getAllSpreadsheets();

--- a/gsheet/samples/getSheetByName.bal
+++ b/gsheet/samples/getSheetByName.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 

--- a/gsheet/samples/getSheets.bal
+++ b/gsheet/samples/getSheets.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 

--- a/gsheet/samples/openSpreadsheetById.bal
+++ b/gsheet/samples/openSpreadsheetById.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name

--- a/gsheet/samples/openSpreadsheetByUrl.bal
+++ b/gsheet/samples/openSpreadsheetByUrl.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name

--- a/gsheet/samples/range.bal
+++ b/gsheet/samples/range.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 

--- a/gsheet/samples/removeSheetById.bal
+++ b/gsheet/samples/removeSheetById.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     int sheetId = 0;
 

--- a/gsheet/samples/removeSheetByName.bal
+++ b/gsheet/samples/removeSheetByName.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 

--- a/gsheet/samples/renameSheet.bal
+++ b/gsheet/samples/renameSheet.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
 

--- a/gsheet/samples/renameSpreadsheet.bal
+++ b/gsheet/samples/renameSpreadsheet.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
 
     // Create Spreadsheet with given name

--- a/gsheet/samples/rows.bal
+++ b/gsheet/samples/rows.bal
@@ -30,9 +30,9 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 
-public function main() {
+public function main() returns error? {
     string spreadsheetId = "";
     string sheetName = "";
     int sheetId = 0;
@@ -70,16 +70,16 @@ public function main() {
     error? spreadsheetRes = spreadsheetClient->setRange(spreadsheetId, sheetName, range);
     if (spreadsheetRes is ()) {
         // Inserts the given number of rows before the given row position in a Worksheet with given ID.
-        error? rowBeforeId = checkpanic spreadsheetClient->addRowsBefore(spreadsheetId, sheetId, 4, 1);
+        error? rowBeforeId = check spreadsheetClient->addRowsBefore(spreadsheetId, sheetId, 4, 1);
         // Inserts the given number of rows before the given row position in a Worksheet with given name.
-        error? rowBefore = checkpanic spreadsheetClient->addRowsBeforeBySheetName(spreadsheetId, sheetName, 5, 1);        
+        error? rowBefore = check spreadsheetClient->addRowsBeforeBySheetName(spreadsheetId, sheetName, 5, 1);        
         // Inserts the given number of rows after the given row position in a Worksheet with given ID.
-        error? rowAfterId = checkpanic spreadsheetClient->addRowsAfter(spreadsheetId, sheetId, 6, 1);
+        error? rowAfterId = check spreadsheetClient->addRowsAfter(spreadsheetId, sheetId, 6, 1);
         // Inserts the given number of rows after the given row position in a Worksheet with given name.
-        error? rowAfter = checkpanic spreadsheetClient->addRowsAfterBySheetName(spreadsheetId, sheetName, 7, 1);
+        error? rowAfter = check spreadsheetClient->addRowsAfterBySheetName(spreadsheetId, sheetName, 7, 1);
         // Create or Update a Row with the given array of values in a Worksheet with given name.
         string[] values = ["Update", "Row", "Values"];
-        error? rowCreate = checkpanic spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
+        error? rowCreate = check spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
         // Gets the values in the given row in a Worksheet with given name.
         sheets:Row|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
         if (row is sheets:Row) {
@@ -88,9 +88,9 @@ public function main() {
             log:printError("Error: " + row.toString());
         }
         // Deletes the given number of rows starting at the given row position in a Worksheet with given ID.
-        error? rowDeleteId = checkpanic spreadsheetClient->deleteRows(spreadsheetId, sheetId, 4, 2);
+        error? rowDeleteId = check spreadsheetClient->deleteRows(spreadsheetId, sheetId, 4, 2);
         // Deletes the given number of rows starting at the given row position in a Worksheet with given name.
-        error? rowDelete = checkpanic spreadsheetClient->deleteRowsBySheetName(spreadsheetId, sheetName, 5, 2);
+        error? rowDelete = check spreadsheetClient->deleteRowsBySheetName(spreadsheetId, sheetName, 5, 2);
 
         // Gets the given range of the Sheet
         sheets:Range|error getValuesResult = spreadsheetClient->getRange(spreadsheetId, sheetName, a1Notation);

--- a/gsheet/samples/rows.bal
+++ b/gsheet/samples/rows.bal
@@ -81,8 +81,8 @@ public function main() {
         string[] values = ["Update", "Row", "Values"];
         error? rowCreate = checkpanic spreadsheetClient->createOrUpdateRow(spreadsheetId, sheetName, 10, values);
         // Gets the values in the given row in a Worksheet with given name.
-        (string|int|decimal)[]|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
-        if (row is (string|int|decimal)[]) {
+        sheets:Row|error row = spreadsheetClient->getRow(spreadsheetId, sheetName, 10);
+        if (row is sheets:Row) {
             log:printInfo(row.toString());
         } else {
             log:printError("Error: " + row.toString());

--- a/gsheet/tests/data-generator/data-generator.bal
+++ b/gsheet/tests/data-generator/data-generator.bal
@@ -29,7 +29,7 @@ sheets:SpreadsheetConfiguration spreadsheetConfig = {
 };
 
 // Connector configuration
-sheets:Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+sheets:Client spreadsheetClient = check new (spreadsheetConfig);
 var randomString = sheets:createRandomUUIDWithoutHyphens();
 string connecterVersion = "0.99.8";
 
@@ -103,7 +103,7 @@ function generateRangeData() returns error? {
 
 function generateFileData() returns error? {
     log:printInfo("SampleDataGenerator -> FileData");
-    stream<sheets:File> response = check spreadsheetClient->getAllSpreadsheets();
+    stream<sheets:File|error> response = check spreadsheetClient->getAllSpreadsheets();
     var file1 = response.next();
     var file2 = response.next();
     var file3 = response.next();

--- a/gsheet/tests/test.bal
+++ b/gsheet/tests/test.bal
@@ -27,7 +27,7 @@ SpreadsheetConfiguration spreadsheetConfig = {
     }
 };
 
-Client spreadsheetClient = checkpanic new (spreadsheetConfig);
+Client spreadsheetClient = check new (spreadsheetConfig);
 
 var randomString = createRandomUUIDWithoutHyphens();
 

--- a/gsheet/tests/test.bal
+++ b/gsheet/tests/test.bal
@@ -343,10 +343,10 @@ function testCreateOrUpdateColumn() {
 }
 function testGetColumn() {
     var spreadsheetRes = spreadsheetClient->getColumn(spreadsheetId, testSheetName, "I", "FORMULA");
-    if (spreadsheetRes is (string|int|decimal)[]) {
+    if (spreadsheetRes is Column) {
         log:printInfo(spreadsheetRes.toString());
         (int|string|decimal)[] expectedValue = ["Update", "Column", "Values"];
-        test:assertEquals(spreadsheetRes, expectedValue, msg = "Failed to get the column values");
+        test:assertEquals(spreadsheetRes.values, expectedValue, msg = "Failed to get the column values");
     } else {
         test:assertFail(spreadsheetRes.message());
     }
@@ -454,10 +454,10 @@ function testCreateOrUpdateRow() {
 }
 function testGetRow() {
     var spreadsheetRes = spreadsheetClient->getRow(spreadsheetId, testSheetName, 10, "FORMULA");
-    if (spreadsheetRes is (string|int|decimal)[]) {
+    if (spreadsheetRes is Row) {
         log:printInfo(spreadsheetRes.toString());
         (int|string|decimal)[] expectedValue = ["Update", "Row", "Values"];
-        test:assertEquals(spreadsheetRes, expectedValue, msg = "Failed to get the row values");
+        test:assertEquals(spreadsheetRes.values, expectedValue, msg = "Failed to get the row values");
     } else {
         test:assertFail(spreadsheetRes.message());
     }
@@ -509,9 +509,9 @@ function testSetCell() {
 }
 function testGetCell() {
     var spreadsheetRes = spreadsheetClient->getCell(spreadsheetId, testSheetName, "H1", "FORMULA");
-    if (spreadsheetRes is (string|int|decimal)) {
+    if (spreadsheetRes is Cell) {
         log:printInfo(spreadsheetRes.toString());
-        test:assertEquals(spreadsheetRes, "ModifiedValue", msg = "Failed to get the cell value");
+        test:assertEquals(spreadsheetRes.value, "ModifiedValue", msg = "Failed to get the cell value");
     } else {
         test:assertFail(spreadsheetRes.message());
     }

--- a/gsheet/types.bal
+++ b/gsheet/types.bal
@@ -118,6 +118,43 @@ public type Range record {
     (int|string|decimal)[][] values;
 };
 
+# Single column in a sheet.
+#
+# + columnPosition - The column letter
+# + values - Values of the given column
+@display {label: "Column"}
+public type Column record {
+    @display {label: "Column Letter"}
+    string columnPosition;
+    @display {label: "Values"}
+    (int|string|decimal)[] values;
+};
+
+# Single row in a sheet.
+#
+# + rowPosition - The row number
+# + values - Values of the given row
+@display {label: "Row"}
+public type Row record {
+    @display {label: "Row Number"}
+    int rowPosition;
+    @display {label: "Values"}
+    (int|string|decimal)[] values;
+};
+
+# Single cell in a sheet.
+#
+# + a1Notation - The column letter followed by the row number.
+#                For example for a single cell "A1" refers to the intersection of column "A" with row "1"
+# + value - Value of the given cell
+@display {label: "Cell"}
+public type Cell record {
+    @display {label: "A1 Notation"}
+    string a1Notation;
+    @display {label: "Value"}
+    (int|string|decimal) value;
+};
+
 # Response from File search 
 #
 # + kind - Identifies what kind of resource is this. Value: the fixed string "drive#fileList".


### PR DESCRIPTION
## Purpose
> 
Some operations return arrays with union types. This is difficult to render in Choreo UI. So we need to change them to record types.
Resolves https://github.com/wso2-enterprise/choreo/issues/4868

Remove usage of checkpanic.
Resolves https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/issues/153

## Goals
> 
Convert array with union return types to records

## Approach
> 
Convert array with union return types to records.
Remove usage of checkpanic.

## Release note
> Convert array with union return types to records

## Documentation
> https://github.com/RolandHewage/module-ballerinax-googleapis.sheets/blob/alpha5_fix_return_records/README.md

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> https://github.com/RolandHewage/module-ballerinax-googleapis.sheets/tree/alpha5_fix_return_records/gsheet/samples


## Test environment
> 
JDK 11
Ubuntu 20.04
Ballerina SLAlpha5 (2.0.0-alpha8-20210423-135000-530658ec)
googleapis.sheets 0.99.9
