### PR TITLE
[SL Alpha 5] Handle check usage in listener user functions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.googleapis.sheets
-version=0.99.11
+version=0.99.12
 ballerinaLangVersion=2.0.0-alpha8-20210423-135000-530658ec

--- a/gsheet/Ballerina.toml
+++ b/gsheet/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "googleapis.sheets"
-version = "0.99.11"
+version = "0.99.12"
 export= ["googleapis.sheets", "googleapis.sheets.listener"]
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
@@ -10,7 +10,7 @@ repository = "https://github.com/ballerina-platform/module-googlespreadsheet"
 
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.99.11.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.99.12.jar"
 groupId = "org.ballerinalang.googleapis.sheets"
 artifactId = "java-wrapper"
-version = "0.99.11"
+version = "0.99.12"

--- a/gsheet/modules/listener/EventDispatcher.bal
+++ b/gsheet/modules/listener/EventDispatcher.bal
@@ -48,21 +48,17 @@ class EventDispatcher {
                 if (self.isOnAppendRowAvailable) {
                     event.eventType = APPEND_ROW;
                     check callOnAppendRowMethod(self.httpService, event);
-                } else {
-                    return error("Unimplemented method [ onAppendRow ] found");
-                }
+                } 
             }
             UPDATE_ROW => {
                 if (self.isOnUpdateRowAvailable) {
                     event.eventType = UPDATE_ROW;
                     check callOnUpdateRowMethod(self.httpService, event);
-                } else {
-                    return error("Unimplemented method [ onUpdateRow ] found");
-                }
+                } 
             }
             _ => {
-                    log:printError("Unrecognized event type [" + eventType.toString() 
-                        + "] found in the response payload");
+                log:printError("Unrecognized event type [" + eventType.toString() 
+                    + "] found in the response payload");
             }
         }
         return;

--- a/gsheet/modules/listener/http_service.bal
+++ b/gsheet/modules/listener/http_service.bal
@@ -42,14 +42,13 @@ service class HttpService {
         if (self.isEventFromMatchingGSheet(spreadsheetId)) {        
             error? dispatchResult = self.eventDispatcher.dispatch(eventType.toString(), event);
             if (dispatchResult is error) {
-                log:printError("Dispatch error or user function implementation error : ", 'error = dispatchResult);
+                log:printError("Dispatching or remote function error : ", 'error = dispatchResult);
                 return;
             }
             return;
         }
         log:printError("Diffrent spreadsheet IDs found : ", configuredSpreadsheetID = self.spreadsheetId, 
             requestSpreadsheetID = spreadsheetId.toString());
-        return;
     }
 
     isolated function isEventFromMatchingGSheet(json spreadsheetId) returns boolean {

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -13,14 +13,14 @@ SheetListenerConfiguration congifuration = {
 listener Listener gsheetListener = new (congifuration);
 
 service / on gsheetListener {
-    isolated remote function onAppendRow(GSheetEvent event) returns error? {
+    isolated remote function onAppendRow(GSheetEvent event) {
         log:printInfo("Received onAppendRow-message ", eventMsg = event);
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");
         }
     }
 
-    isolated remote function onUpdateRow(GSheetEvent event) returns error? {
+    isolated remote function onUpdateRow(GSheetEvent event) {
         log:printInfo("Received onUpdateRow-message ", eventMsg = event);
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -13,15 +13,14 @@ SheetListenerConfiguration congifuration = {
 listener Listener gsheetListener = new (congifuration);
 
 service / on gsheetListener {
-    isolated remote function onAppendRow(GSheetEvent event) {
+    isolated remote function onAppendRow(GSheetEvent event) returns error? {
         log:printInfo("Received onAppendRow-message ", eventMsg = event);
-        string? receivedData = event?.eventInfo?.spreadsheetName;
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");
         }
     }
 
-    isolated remote function onUpdateRow(GSheetEvent event) {
+    isolated remote function onUpdateRow(GSheetEvent event) returns error? {
         log:printInfo("Received onUpdateRow-message ", eventMsg = event);
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");
@@ -44,7 +43,7 @@ function testOnAppendRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 200);
+        test:assertEquals(response.statusCode, 202);
     } else {
         test:assertFail("GSheet listener onAppendRow test failed");
     }
@@ -63,7 +62,7 @@ function testOnUpdateRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 200);
+        test:assertEquals(response.statusCode, 202);
     } else {
         test:assertFail("GSheet listener onUpdateRow test failed");
     }


### PR DESCRIPTION
## Purpose
> 
The problem with our listener functions are, as soon as we receive the event, we respond with 200 ok, and then we dispatch the event. At user function implementation if there was an error we throw it up. In this case, as we have already responded with 200 OK, http client cannot convert the error and respond again, bacause it cannot respond to the same message twice.

When using check in listener user function implementations, the error is returned back to the service caller. Ideally this error should be logged & should not return back to the service caller. This should be handled within the connector.

Bump version to 0.99.12

Resolves https://github.com/wso2-enterprise/choreo/issues/6017

## Goals
> Handle check usage in listener user functions

## Approach
> 
Log the user function implementation errors in the connector itself & avoid returning any error after responding HTTP 202 accept.
Bump version to 0.99.12

## Release note
> Log the user function implementation errors within the connector

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
## Test environment
> 
JDK 11
Ballerina SLAlpha5
Ubuntu 20.04