### PR TITLE
 [SL Beta 2] Return http status OK response after user logic execution in listener

### DIFF
--- a/gsheet/modules/listener/EventDispatcher.bal
+++ b/gsheet/modules/listener/EventDispatcher.bal
@@ -48,21 +48,17 @@ class EventDispatcher {
                 if (self.isOnAppendRowAvailable) {
                     event.eventType = APPEND_ROW;
                     check callOnAppendRowMethod(self.httpService, event);
-                } else {
-                    return error("Unimplemented method [ onAppendRow ] found");
-                }
+                } 
             }
             UPDATE_ROW => {
                 if (self.isOnUpdateRowAvailable) {
                     event.eventType = UPDATE_ROW;
                     check callOnUpdateRowMethod(self.httpService, event);
-                } else {
-                    return error("Unimplemented method [ onUpdateRow ] found");
-                }
+                } 
             }
             _ => {
-                    log:printError("Unrecognized event type [" + eventType.toString() 
-                        + "] found in the response payload");
+                log:printError("Unrecognized event type [" + eventType.toString() 
+                    + "] found in the response payload");
             }
         }
         return;

--- a/gsheet/modules/listener/Module.md
+++ b/gsheet/modules/listener/Module.md
@@ -250,3 +250,33 @@ service / on gSheetListener {
 ```
 
 More Samples are available at "https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/tree/master/samples".
+
+> **NOTE:**
+At user function implementation if there was an error we throw it up & the http client will return status 500 error. 
+If no any error occured & the user logic is executed successfully we respond with status 200 OK. 
+If the user logic in listener remote operations include heavy processing, the user may face http timeout issues. 
+To solve this issue, user must use asynchronous processing when it includes heavy processing.
+
+```ballerina
+import ballerinax/googleapis.sheets.'listener as sheetsListener;
+
+configurable int port = ?;
+configurable string spreadsheetId = ?;
+
+sheetsListener:SheetListenerConfiguration congifuration = {
+    port: port,
+    spreadsheetId: spreadsheetId
+};
+
+listener sheetsListener:Listener gSheetListener = new (congifuration);
+
+service / on gsheetListener {
+    isolated remote function onAppendRow(GSheetEvent event) {
+       _ = @strand { thread: "any" } start userLogic(event);
+    }
+}
+
+function userLogic(sheetsListener:GSheetEvent event) returns error? {
+    // Write your logic here
+}
+```

--- a/gsheet/modules/listener/http_service.bal
+++ b/gsheet/modules/listener/http_service.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/log;
 
 service class HttpService {
     private EventDispatcher eventDispatcher;
@@ -35,21 +34,18 @@ service class HttpService {
         EventInfo eventInfo = check payload.cloneWithType(EventInfo);
         event.eventInfo = eventInfo; 
 
-        http:Response res = new;
-        res.statusCode = http:STATUS_ACCEPTED;
-        check caller->respond(res); 
-
         if (self.isEventFromMatchingGSheet(spreadsheetId)) {        
             error? dispatchResult = self.eventDispatcher.dispatch(eventType.toString(), event);
             if (dispatchResult is error) {
-                log:printError("Dispatch error or user function implementation error : ", 'error = dispatchResult);
-                return;
+                return error("Dispatching or remote function error : ", 'error = dispatchResult);
             }
+            http:Response res = new;
+            res.statusCode = http:STATUS_OK;
+            check caller->respond(res); 
             return;
         }
-        log:printError("Diffrent spreadsheet IDs found : ", configuredSpreadsheetID = self.spreadsheetId, 
+        return error("Diffrent spreadsheet IDs found : ", configuredSpreadsheetID = self.spreadsheetId, 
             requestSpreadsheetID = spreadsheetId.toString());
-        return;
     }
 
     isolated function isEventFromMatchingGSheet(json spreadsheetId) returns boolean {

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -13,14 +13,14 @@ SheetListenerConfiguration congifuration = {
 listener Listener gsheetListener = new (congifuration);
 
 service / on gsheetListener {
-    isolated remote function onAppendRow(GSheetEvent event) returns error? {
+    isolated remote function onAppendRow(GSheetEvent event) {
         log:printInfo("Received onAppendRow-message ", eventMsg = event);
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");
         }
     }
 
-    isolated remote function onUpdateRow(GSheetEvent event) returns error? {
+    isolated remote function onUpdateRow(GSheetEvent event) {
         log:printInfo("Received onUpdateRow-message ", eventMsg = event);
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");
@@ -43,7 +43,7 @@ function testOnAppendRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 202);
+        test:assertEquals(response.statusCode, 200);
     } else {
         test:assertFail("GSheet listener onAppendRow test failed");
     }
@@ -62,7 +62,7 @@ function testOnUpdateRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 202);
+        test:assertEquals(response.statusCode, 200);
     } else {
         test:assertFail("GSheet listener onUpdateRow test failed");
     }

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -13,15 +13,14 @@ SheetListenerConfiguration congifuration = {
 listener Listener gsheetListener = new (congifuration);
 
 service / on gsheetListener {
-    isolated remote function onAppendRow(GSheetEvent event) {
+    isolated remote function onAppendRow(GSheetEvent event) returns error? {
         log:printInfo("Received onAppendRow-message ", eventMsg = event);
-        string? receivedData = event?.eventInfo?.spreadsheetName;
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");
         }
     }
 
-    isolated remote function onUpdateRow(GSheetEvent event) {
+    isolated remote function onUpdateRow(GSheetEvent event) returns error? {
         log:printInfo("Received onUpdateRow-message ", eventMsg = event);
         if (event?.eventInfo?.spreadsheetName != "TestListener") {
             log:printError("Received event data doesn't match");
@@ -44,7 +43,7 @@ function testOnAppendRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 200);
+        test:assertEquals(response.statusCode, 202);
     } else {
         test:assertFail("GSheet listener onAppendRow test failed");
     }
@@ -63,7 +62,7 @@ function testOnUpdateRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 200);
+        test:assertEquals(response.statusCode, 202);
     } else {
         test:assertFail("GSheet listener onUpdateRow test failed");
     }

--- a/gsheet/samples/listener/trigger_on_heavy_processing.bal
+++ b/gsheet/samples/listener/trigger_on_heavy_processing.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerinax/googleapis.sheets.'listener as sheetsListener;
+
+configurable int port = ?;
+configurable string spreadsheetId = ?;
+
+sheetsListener:SheetListenerConfiguration congifuration = {
+    port: port,
+    spreadsheetId: spreadsheetId
+};
+
+listener sheetsListener:Listener gSheetListener = new (congifuration);
+
+service / on gSheetListener {
+    remote function onAppendRow(sheetsListener:GSheetEvent event) returns error? {
+        // Write your logic here.....
+        log:printInfo("Received onAppendRow-message ", eventMsg = event);
+        _ = @strand { thread: "any" } start userLogic(event);
+    }
+}
+
+function userLogic(sheetsListener:GSheetEvent event) returns error? {
+    // Write your logic here
+    log:printInfo("Received onAppendRow-message 1 ", eventMsg = event);
+}


### PR DESCRIPTION
## Purpose
> 
The problem with our listener functions are, as soon as we receive the event, we respond with 200 ok, and then we dispatch the event. At user function implementation if there was an error we throw it up. In this case, as we have already responded with 200 OK, http client cannot convert the error and respond again, bacause it cannot respond to the same message twice.

When using check in listener user function implementations, the error is returned back to the service caller. Ideally this error should be logged & should not return back to the service caller. This should be handled within the connector.

## Goals
> Handle check usage in listener user functions

## Approach
> 
Log the user function implementation errors in the connector itself & avoid returning any error after responding HTTP 202 accept.

## Release note
> Log the user function implementation errors within the connector

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
## Test environment
> 
JDK 11
Ballerina 2.0.0-beta.2-20210621-194000-70c97122
Ubuntu 20.04