### PR TITLE
[SL Alpha 5] Return http status OK response after user logic execution in listener

### DIFF
--- a/gsheet/modules/listener/Module.md
+++ b/gsheet/modules/listener/Module.md
@@ -250,3 +250,33 @@ service / on gSheetListener {
 ```
 
 More Samples are available at "https://github.com/ballerina-platform/module-ballerinax-googleapis.sheets/tree/master/samples".
+
+> **NOTE:**
+At user function implementation if there was an error we throw it up & the http client will return status 500 error. 
+If no any error occured & the user logic is executed successfully we respond with status 200 OK. 
+If the user logic in listener remote operations include heavy processing, the user may face http timeout issues. 
+To solve this issue, user must use asynchronous processing when it includes heavy processing.
+
+```ballerina
+import ballerinax/googleapis.sheets.'listener as sheetsListener;
+
+configurable int port = ?;
+configurable string spreadsheetId = ?;
+
+sheetsListener:SheetListenerConfiguration congifuration = {
+    port: port,
+    spreadsheetId: spreadsheetId
+};
+
+listener sheetsListener:Listener gSheetListener = new (congifuration);
+
+service / on gsheetListener {
+    isolated remote function onAppendRow(GSheetEvent event) {
+       _ = @strand { thread: "any" } start userLogic(event);
+    }
+}
+
+function userLogic(sheetsListener:GSheetEvent event) returns error? {
+    // Write your logic here
+}
+```

--- a/gsheet/modules/listener/http_service.bal
+++ b/gsheet/modules/listener/http_service.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/log;
 
 service class HttpService {
     private EventDispatcher eventDispatcher;
@@ -35,19 +34,17 @@ service class HttpService {
         EventInfo eventInfo = check payload.cloneWithType(EventInfo);
         event.eventInfo = eventInfo; 
 
-        http:Response res = new;
-        res.statusCode = http:STATUS_ACCEPTED;
-        check caller->respond(res); 
-
         if (self.isEventFromMatchingGSheet(spreadsheetId)) {        
             error? dispatchResult = self.eventDispatcher.dispatch(eventType.toString(), event);
             if (dispatchResult is error) {
-                log:printError("Dispatching or remote function error : ", 'error = dispatchResult);
-                return;
+                return error("Dispatching or remote function error : ", 'error = dispatchResult);
             }
+            http:Response res = new;
+            res.statusCode = http:STATUS_OK;
+            check caller->respond(res); 
             return;
         }
-        log:printError("Diffrent spreadsheet IDs found : ", configuredSpreadsheetID = self.spreadsheetId, 
+        return error("Diffrent spreadsheet IDs found : ", configuredSpreadsheetID = self.spreadsheetId, 
             requestSpreadsheetID = spreadsheetId.toString());
     }
 

--- a/gsheet/modules/listener/tests/test.bal
+++ b/gsheet/modules/listener/tests/test.bal
@@ -43,7 +43,7 @@ function testOnAppendRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 202);
+        test:assertEquals(response.statusCode, 200);
     } else {
         test:assertFail("GSheet listener onAppendRow test failed");
     }
@@ -62,7 +62,7 @@ function testOnUpdateRowTrigger() {
 
     http:Response|error response = httpClient->post("/", request);
     if (response is http:Response) {
-        test:assertEquals(response.statusCode, 202);
+        test:assertEquals(response.statusCode, 200);
     } else {
         test:assertFail("GSheet listener onUpdateRow test failed");
     }

--- a/gsheet/samples/listener/trigger_on_heavy_processing.bal
+++ b/gsheet/samples/listener/trigger_on_heavy_processing.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerinax/googleapis.sheets.'listener as sheetsListener;
+
+configurable int port = ?;
+configurable string spreadsheetId = ?;
+
+sheetsListener:SheetListenerConfiguration congifuration = {
+    port: port,
+    spreadsheetId: spreadsheetId
+};
+
+listener sheetsListener:Listener gSheetListener = new (congifuration);
+
+service / on gSheetListener {
+    remote function onAppendRow(sheetsListener:GSheetEvent event) returns error? {
+        // Write your logic here.....
+        log:printInfo("Received onAppendRow-message ", eventMsg = event);
+        _ = @strand { thread: "any" } start userLogic(event);
+    }
+}
+
+function userLogic(sheetsListener:GSheetEvent event) returns error? {
+    // Write your logic here
+    log:printInfo("Received onAppendRow-message 1 ", eventMsg = event);
+}


### PR DESCRIPTION
## Purpose
> 
The problem with our listener functions are, as soon as we receive the event, we respond with status 200 OK, and then we dispatch the event. At user function implementation if there was an error we throw it up. In this case, as we have already responded with 200 OK, http client cannot convert the error and respond again, bacause it cannot respond to the same message twice.

Ideally we should respond with status 200 OK only after dispatching the event. At user function implementation if there was an error we throw it up & the http client will return status 500 error. If no any error occured & the user logic is executed successfully we should respond with status 200 OK.

Resolves https://github.com/wso2-enterprise/choreo/issues/6085

If the user logic in listener remote operations include heavy processing, the user may face http timeout issues. To solve this issue, user must use asynchronous processing when it includes heavy processing.

```
import ballerinax/googleapis.sheets.'listener as sheetsListener;

configurable int port = ?;
configurable string spreadsheetId = ?;

sheetsListener:SheetListenerConfiguration congifuration = {
    port: port,
    spreadsheetId: spreadsheetId
};

listener sheetsListener:Listener gSheetListener = new (congifuration);

service / on gsheetListener {
    isolated remote function onAppendRow(GSheetEvent event) {
       _ = @strand { thread: "any" } start userLogic1(event);
       _ = @strand { thread: "any" } start userLogic2(event);
    }
}

function userLogic1(sheetsListener:GSheetEvent event) returns error? {
    // Write your logic here
}

function userLogic2(sheetsListener:GSheetEvent event) returns error? {
    // Write your logic here
}
```

## Goals
> Return http response after user logic execution in listener

## Approach
> 
Respond with status 200 OK only after dispatching the event
At user function implementation if there was an error we throw it up & the http client will return status 500 error.
If no any error occured & the user logic is executed successfully we respond with status 200 OK.

## Release note
> 
At listener user function implementation if there was an error we throw it up & the http client will return status 500 Error.
If no any error occured & the user logic is executed successfully we respond with status 200 OK.

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
JDK 11
Ballerina 2.0.0-beta.2-20210621-194000-70c97122
Ubuntu 20.04
 
## Learning
> 
https://github.com/ballerina-platform/module-ballerina-websubhub/blob/main/websubhub-examples/kafka-hub/hub/start_hub.bal#L31
https://github.com/ballerina-platform/ballerina-distribution/releases/tag/vswan-lake-alpha5.7
https://www.youtube.com/watch?v=tsKZ_u_uIAs