### PR TITLE
Make `SimpleHttpService` service type distinct & fix warning messages

### DIFF
--- a/gsheet/Dependencies.toml
+++ b/gsheet/Dependencies.toml
@@ -162,9 +162,7 @@ org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.array"},
-	{org = "ballerina", name = "lang.value"}
+	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
@@ -302,7 +300,8 @@ dependencies = [
 ]
 modules = [
 	{org = "ballerinax", packageName = "googleapis.sheets", moduleName = "googleapis.sheets"},
-	{org = "ballerinax", packageName = "googleapis.sheets", moduleName = "googleapis.sheets.listener"}
+	{org = "ballerinax", packageName = "googleapis.sheets", moduleName = "googleapis.sheets.listener"},
+	{org = "ballerinax", packageName = "googleapis.sheets", moduleName = "googleapis.sheets.sheets"}
 ]
 
 

--- a/gsheet/client.bal
+++ b/gsheet/client.bal
@@ -596,7 +596,7 @@ public isolated client class Client {
         request.setJsonPayload(<@untainted>jsonPayload);
         http:Response httpResponse = <http:Response> check self.httpClient->put(<@untainted>requestPath, request);
         if (httpResponse.statusCode == http:STATUS_OK) {
-            json jsonResponse = check httpResponse.getJsonPayload();
+            _ = check httpResponse.getJsonPayload();
             return; 
         }
         return getErrorMessage(httpResponse);
@@ -905,7 +905,7 @@ public isolated client class Client {
         request.setJsonPayload(<@untainted>jsonPayload);
         http:Response httpResponse = <http:Response> check self.httpClient->put(<@untainted>requestPath, request);
         if (httpResponse.statusCode == http:STATUS_OK) {
-            json jsonResponse = check httpResponse.getJsonPayload();
+            _ = check httpResponse.getJsonPayload();
             return; 
         }
         return getErrorMessage(httpResponse);

--- a/gsheet/modules/listener/http_service.bal
+++ b/gsheet/modules/listener/http_service.bal
@@ -18,6 +18,7 @@ import ballerina/http;
 import ballerina/log;
 
 isolated service class HttpService {
+    *http:Service;
     private final string spreadsheetId;
     private final boolean isOnAppendRowAvailable;
     private final boolean isOnUpdateRowAvailable;

--- a/gsheet/modules/listener/simple_http_service.bal
+++ b/gsheet/modules/listener/simple_http_service.bal
@@ -14,4 +14,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type SimpleHttpService service object {};
+public type SimpleHttpService distinct service object {};

--- a/gsheet/stream_implementer.bal
+++ b/gsheet/stream_implementer.bal
@@ -42,6 +42,8 @@ class SpreadsheetStream {
             self.index += 1;
             return file;
         }
+
+        return;
     }
 
     isolated function fetchFiles() returns @tainted File[]|error {


### PR DESCRIPTION
# Description

All the standard library service definitions are now made `distinct`. Therefore, if you have created services without using the service declaration, you need to do the type inclusion explicitly as follows.

```
public service class MyHttpService {
    *http:Service;
   // some resources
}

public function main() returns error? {
    Listener l = check new;
    MyService myService = new;
    check l.attach(myService, "/foo");  
}

Or

http:Service myService = service object {
   // some resources
}
```

Fixes # ([issue](https://github.com/ballerina-platform/ballerina-extended-library/issues/158))

One line release note: 
- Make SimpleHttpService service type distinct 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Build & run the test cases using the following pack
https://github.com/ballerina-platform/ballerina-distribution/actions/runs/1478991785

**Test Configuration**:
* Ballerina Version: SLBeta4
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
