### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/gsheet/Ballerina.toml
+++ b/gsheet/Ballerina.toml
@@ -1,8 +1,8 @@
 [package]
-distribution = "2201.0.0"
+distribution = "2201.0.3"
 org = "ballerinax"
 name = "googleapis.sheets"
-version = "2.2.0"
+version = "3.0.0"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Productivity/Spreadsheets", "Cost/Free", "Vendor/Google"]


### PR DESCRIPTION
# Description
- Bump connector version to `3.0.0` after removing the listener module